### PR TITLE
Ensure path exists before initialising FileHandler

### DIFF
--- a/cli/helpers.py
+++ b/cli/helpers.py
@@ -31,9 +31,6 @@ def initialise_logging(path: str, logging_mode: str) -> None:
     formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(name)s] %(message)s')
     root_logger = logging.getLogger()
 
-    # Ensure path exists before writing log
-    if not os.path.exists(path):
-        os.makedirs(path)
     file_handler = logging.FileHandler(os.path.join(path, f"log.{get_timestamp_now()}"))
     file_handler.setFormatter(formatter)
 
@@ -437,11 +434,11 @@ class CLIParser(CLICommandGroup):
 
             args = vars(parser.parse_args(args))
 
-            initialise_logging(args['temp-dir'], args['logging'])
-
             initialise_storage_folder(args['temp-dir'], 'temp-dir')
 
             initialise_storage_folder(args['keystore'], 'keystore')
+
+            initialise_logging(args['temp-dir'], args['logging'])
 
             super().execute(args)
 


### PR DESCRIPTION


### Description
FileHandler will give a FileNotFoundError exception if path does not exist during initialisation.

```
Traceback (most recent call last):
  File "/home/reynoldmok/saas-middleware/saas_cli.py", line 91, in <module>
    cli.execute(sys.argv[1:])
  File "/home/reynoldmok/saas-middleware/cli/helpers.py", line 437, in execute
    initialise_logging(args['temp-dir'], args['logging'])
  File "/home/reynoldmok/saas-middleware/cli/helpers.py", line 34, in initialise_logging
    file_handler = logging.FileHandler(os.path.join(path, f"log.{get_timestamp_now()}"))
  File "/usr/lib/python3.9/logging/__init__.py", line 1146, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib/python3.9/logging/__init__.py", line 1175, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
FileNotFoundError: [Errno 2] No such file or directory: '/home/reynoldmok/.temp/log.1630503248073'
```

