### PR TITLE
Remove handlers after logging test

### DIFF
--- a/saas/logging.py
+++ b/saas/logging.py
@@ -26,8 +26,7 @@ class Logging:
             root_logger.setLevel(level)
 
             # remove all handlers -> we will create our own
-            for handler in root_logger.handlers:
-                root_logger.removeHandler(handler)
+            cls.remove_all_handlers()
 
             # do we have a default log path?
             if log_path:
@@ -56,3 +55,12 @@ class Logging:
             logger.addHandler(file_handler)
 
         return logger
+
+    @staticmethod
+    def remove_all_handlers():
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers:
+            # Flush and close any open streams
+            handler.flush()
+            handler.close()
+            root_logger.removeHandler(handler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,6 +14,8 @@ class LoggingTestCase(unittest.TestCase, TestCaseBase):
         self.initialise()
 
     def tearDown(self):
+        # Remove all handlers (especially FileHandlers) to prevent errors in logging (e.g. directory does not exist)
+        Logging.remove_all_handlers()
         self.cleanup()
 
     def test_defaults(self):


### PR DESCRIPTION
### Description
This fixes errors that show up when running all the test cases in PyCharm. These would only appear in tests that run after the logging test. Running each test file individually would not cause this to happen.

```python
--- Logging error ---
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/handlers.py", line 73, in emit
    if self.shouldRollover(record):
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/handlers.py", line 192, in shouldRollover
    self.stream = self._open()
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/__init__.py", line 1175, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
FileNotFoundError: [Errno 2] No such file or directory: '/Users/reynoldmok/testing/1641935432700/log'
```