### PR TITLE
238 support data licenses

### DIFF
--- a/saas/dor/schemas.py
+++ b/saas/dor/schemas.py
@@ -70,8 +70,16 @@ class GPPDataObject(DataObject):
     gpp: GitProcessorPointer
 
 
+class DataObjectLicense(BaseModel):
+    by: bool  # if True -> must credit creators
+    sa: bool  # if True -> adaptations (derivatives) must use same terms
+    nc: bool  # if True -> must not be used for commercial purposes
+    nd: bool  # if True -> not allowed to create derivatives
+
+
 class CDataObject(DataObject):
     content_encrypted: bool
+    license: DataObjectLicense
     recipe: Optional[DataObjectRecipe]
 
 
@@ -93,6 +101,7 @@ class AddCDataObjectParameters(AddDataObjectParameters):
     data_format: str
     access_restricted: bool
     content_encrypted: bool
+    license: DataObjectLicense
     recipe: Optional[DataObjectRecipe]
 
 

--- a/saas/dor/service.py
+++ b/saas/dor/service.py
@@ -395,7 +395,8 @@ class DORService:
                                          access=[owner.id], tags={},
                                          details={
                                              'content_encrypted': p.content_encrypted,
-                                             'recipe': p.recipe.dict() if p.recipe else None
+                                             'license': p.license.dict(),
+                                             'recipe': p.recipe.dict() if p.recipe else None,
                                          }))
             session.commit()
             logger.info(f"database record for data object '{obj_id}' added with c_hash={c_hash}.")
@@ -583,6 +584,7 @@ class DORService:
                     'tags': record.tags,
 
                     'content_encrypted': details['content_encrypted'],
+                    'license': details['license'],
                     'recipe': details['recipe'] if 'recipe' in details else None
                 })
 

--- a/tests/test_service_dor.py
+++ b/tests/test_service_dor.py
@@ -98,6 +98,25 @@ class DORTestCase(unittest.TestCase, TestCaseBase):
         assert(len(result['created']['creators_iid']) == 1)
         assert(owner.id in result['created']['creators_iid'])
 
+    def test_add_c_license(self):
+        owner = self._node.identity
+
+        # create content
+        content_path = os.path.join(self.wd_path, 'test.json')
+        with open(content_path, 'w') as f:
+            f.write(json.dumps({
+                'a': random.randint(0, 9999)
+            }))
+
+        result = self._dor.add_data_object(content_path, owner, False, False, 'JSON', 'json', license_by=True)
+
+        print(result)
+        assert(result is not None)
+        assert(result['license']['by'])
+        assert(not result['license']['sa'])
+        assert(not result['license']['nc'])
+        assert(not result['license']['nd'])
+
     def test_add_c(self):
         owner = self._node.identity
 


### PR DESCRIPTION
### Description
Closes #238 

### Notes
Introduced CC-style license information to the data object meta information. License information is not currently used anywhere but in the future it can be used, for example, to find license violations and provide license information to users as part of the provenance functionality.